### PR TITLE
Clean up stdout and stderr

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -64,6 +64,7 @@ export async function $(pieces, ...args) {
       stdout += decoded
       combined += decoded
     }
+    child.stdout.close()
   })()
   let stderrPromise = (async function() {
     for await (const chunk of iter(child.stderr)) {
@@ -72,9 +73,11 @@ export async function $(pieces, ...args) {
       stderr += decoded
       combined += decoded
     }
+    child.stderr.close()
   })()
   const { success, code } = await child.status()
   await Promise.all([stdoutPromise, stderrPromise])
+  child.close()
   const output = new ProcessOutput({code, stdout, stderr, combined, __from})
   if (success)
     return output


### PR DESCRIPTION
According to [the document of Deno.Process](https://doc.deno.land/builtin/stable#Deno.Process),

> If stdout and/or stderr were set to "piped", they must be closed manually before the process can exit.

stdout and stderr need to be closed. Can I add the clean up lines there?