### PR TITLE
[DO NOT MERGE] Use TextDecoder in stream mode

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -32,7 +32,8 @@ function substitute(arg) {
   return arg
 }
 
-let decoder = new TextDecoder();
+let stdout_decoder = new TextDecoder();
+let stderr_decoder = new TextDecoder();
 
 export async function $(pieces, ...args) {
   let __from = (new Error().stack.split('at ')[2]).trim()
@@ -59,7 +60,7 @@ export async function $(pieces, ...args) {
   let stdout = '', stderr = '', combined = ''
   let stdoutPromise = (async function() {
     for await (const chunk of iter(child.stdout)) {
-      const decoded = decoder.decode(chunk)
+      const decoded = stdout_decoder.decode(chunk, {stream: true})
       if ($.verbose) await Deno.stdout.write(chunk)
       stdout += decoded
       combined += decoded
@@ -68,7 +69,7 @@ export async function $(pieces, ...args) {
   })()
   let stderrPromise = (async function() {
     for await (const chunk of iter(child.stderr)) {
-      const decoded = decoder.decode(chunk)
+      const decoded = stderr_decoder.decode(chunk, {stream: true})
       if ($.verbose) await Deno.stderr.write(chunk)
       stderr += decoded
       combined += decoded
@@ -173,5 +174,6 @@ async function exec(cmd) {
   const stdout = await stdoutPromise
   proc.stdout.close()
   proc.close()
+  let decoder = new TextDecoder()
   return decoder.decode(stdout)
 }


### PR DESCRIPTION
This is not a real fix. Just to report an issue of the current code.

If a command output contains a non-ASCII character, whose UTF-8 representation needs multiple bytes for that codepoint, and the chunk boundary splits the these bytes into separate chunks, then `TextDecoder#decode` fails to decode the character at the boundary.

E.g.
```console.log((await $`echo -ne '\\xc3'; sleep 0s; echo -e '\\xa7'`).stdout)```
on zx-deno prints "��", while `echo -ne '\xc3'; sleep 0s; echo -e '\xa7'` on bash prints "ç".

We could resolve the issue if we could use the TextDecoder in the stream mode. Though Deno's TextDecoder doesn't support the stream mode yet, (cf. https://github.com/denoland/deno/issues/5351).

Another solution is to accumulate copies of `stdin`, `stderr`, and `combined` outut into arrays of `Uint8Array`, and decode them at once at `ProcessOutput` construction. Though `combined` may be still broken in this way.