### PR TITLE
bump std dependencies, with `udd **/*js`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {readAll, iter} from 'https://deno.land/std@0.95.0/io/util.ts'
-import {existsSync} from 'https://deno.land/std@0.95.0/fs/exists.ts'
-import * as colors from 'https://deno.land/std@0.95.0/fmt/colors.ts'
+import {readAll, iter} from 'https://deno.land/std@0.106.0/io/util.ts'
+import {existsSync} from 'https://deno.land/std@0.106.0/fs/exists.ts'
+import * as colors from 'https://deno.land/std@0.106.0/fmt/colors.ts'
 import {singleArgument as escape} from 'https://deno.land/x/shell_escape@1.0.0/index.ts'
 
 export {colors}

--- a/test.mjs
+++ b/test.mjs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {strict as assert} from 'https://deno.land/std@0.95.0/node/assert.ts'
+import {strict as assert} from 'https://deno.land/std@0.106.0/node/assert.ts'
 
 {
   let hello = await $`echo Error >&2; echo Hello`

--- a/zx.mjs
+++ b/zx.mjs
@@ -14,10 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {readAll} from 'https://deno.land/std@0.95.0/io/util.ts'
-import {resolve} from 'https://deno.land/std@0.95.0/path/mod.ts'
-import * as fs from 'https://deno.land/std@0.95.0/node/fs.ts';
-import * as os from 'https://deno.land/std@0.95.0/node/os.ts';
+import {readAll} from 'https://deno.land/std@0.106.0/io/util.ts'
+import {resolve} from 'https://deno.land/std@0.106.0/path/mod.ts'
+import * as fs from 'https://deno.land/std@0.106.0/node/fs.ts';
+import * as os from 'https://deno.land/std@0.106.0/node/os.ts';
 import {$, cd, question, colors, fetch, ProcessOutput} from './index.mjs'
 import {version} from './version.js'
 


### PR DESCRIPTION
I'm currently running
```
$ deno --version
deno 1.13.2 (release, x86_64-apple-darwin)
v8 9.3.345.11
typescript 4.3.5
```

and this complains about some typing problems in std@0.95.0

I ran `udd **/*js` to bump the versions

I can now run `deno install -A --unstable mod.mjs` without any problems.

- [ ] Tests pass
I'm not sure how to run the tests

- [ ] Appropriate changes to README are included in PR
I don't think any are needed